### PR TITLE
fix: add missing lb_vip attribute back to ilb based template userdata…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1 (February 25, 2025)
+BUG FIXES:
+* fix: add missing lb_vip attribute back to ilb based template userdata file generation
+
 ## 0.2.0 (February 13, 2025)
 FEATURES:
 * Official support for HashiCorp Vault for secrets storage as an alternative to GCP Secret Manager

--- a/examples/base_cc_ilb/main.tf
+++ b/examples/base_cc_ilb/main.tf
@@ -118,7 +118,8 @@ locals {
   "hcp_vault_secret_path": "${var.hcp_vault_secret_path}",
   "hcp_vault_role_name": "${var.hcp_vault_role_name}",
   "hcp_gcp_auth_role_type": "${var.hcp_gcp_auth_role_type}",
-  "gcp_service_account": "${module.iam_service_account.service_account}"
+  "gcp_service_account": "${module.iam_service_account.service_account}",
+  "lb_vip": "${module.ilb.ilb_ip_address}"
 }
 USERDATA
 
@@ -128,7 +129,8 @@ USERDATA
   "cc_url": "${var.cc_vm_prov_url}",
   "secret_name": "${var.secret_name}",
   "http_probe_port": ${var.http_probe_port},
-  "gcp_service_account": "${module.iam_service_account.service_account}"
+  "gcp_service_account": "${module.iam_service_account.service_account}",
+  "lb_vip": "${module.ilb.ilb_ip_address}"
 }
 USERDATA
 

--- a/examples/base_cc_ilb_zpa/main.tf
+++ b/examples/base_cc_ilb_zpa/main.tf
@@ -118,7 +118,8 @@ locals {
   "hcp_vault_secret_path": "${var.hcp_vault_secret_path}",
   "hcp_vault_role_name": "${var.hcp_vault_role_name}",
   "hcp_gcp_auth_role_type": "${var.hcp_gcp_auth_role_type}",
-  "gcp_service_account": "${module.iam_service_account.service_account}"
+  "gcp_service_account": "${module.iam_service_account.service_account}",
+  "lb_vip": "${module.ilb.ilb_ip_address}"
 }
 USERDATA
 
@@ -128,7 +129,8 @@ USERDATA
   "cc_url": "${var.cc_vm_prov_url}",
   "secret_name": "${var.secret_name}",
   "http_probe_port": ${var.http_probe_port},
-  "gcp_service_account": "${module.iam_service_account.service_account}"
+  "gcp_service_account": "${module.iam_service_account.service_account}",
+  "lb_vip": "${module.ilb.ilb_ip_address}"
 }
 USERDATA
 

--- a/examples/cc_ilb/main.tf
+++ b/examples/cc_ilb/main.tf
@@ -89,7 +89,8 @@ locals {
   "hcp_vault_secret_path": "${var.hcp_vault_secret_path}",
   "hcp_vault_role_name": "${var.hcp_vault_role_name}",
   "hcp_gcp_auth_role_type": "${var.hcp_gcp_auth_role_type}",
-  "gcp_service_account": "${module.iam_service_account.service_account}"
+  "gcp_service_account": "${module.iam_service_account.service_account}",
+  "lb_vip": "${module.ilb.ilb_ip_address}"
 }
 USERDATA
 
@@ -99,7 +100,8 @@ USERDATA
   "cc_url": "${var.cc_vm_prov_url}",
   "secret_name": "${var.secret_name}",
   "http_probe_port": ${var.http_probe_port},
-  "gcp_service_account": "${module.iam_service_account.service_account}"
+  "gcp_service_account": "${module.iam_service_account.service_account}",
+  "lb_vip": "${module.ilb.ilb_ip_address}"
 }
 USERDATA
 


### PR DESCRIPTION
fix: add missing lb_vip attribute back to ilb based template userdata…

the attribute is required for successful ILB based health probe responses from CC
