### PR TITLE
[ZTW-9052] restrict cloud function roles for least privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2 (May 11, 2026)
+ENHANCEMENTS:
+* update: terraform-zscc-cloud-function-gcp module to use a custom project IAM role with minimal Compute Engine permissions instead of the broad roles/compute.instanceAdmin.v1 binding
+
 ## 0.3.1 (March 9, 2026)
 BUG FIXES:
 * add: variable grant_pubsub_editor support for autoscaling deployment templates Service Account IAM Role module with default enabled

--- a/modules/terraform-zscc-cloud-function-gcp/README.md
+++ b/modules/terraform-zscc-cloud-function-gcp/README.md
@@ -29,7 +29,7 @@ This module provisions the following GCP resources to support the monitoring and
 -   **Google Cloud Storage Object**: The Python source code, which must be located in the `zscaler-cc-cloud-run-function/` subdirectory within this module, is zipped and uploaded to the GCS bucket.
 -   **Google IAM Service Account**: A dedicated service account is created for the Cloud Functions to operate under the principle of least privilege. You can also provide an existing service account.
 -   **Google Project IAM Bindings**: The service account is granted the necessary roles to perform its tasks:
-    -   `Compute Instance Admin (v1)`: To manage VM instances (i.e., delete unhealthy ones from MIGs).
+    -   `Custom Cloud Function Compute Role`: A custom IAM role with minimal Compute Engine permissions required for health monitoring, autoscaling, and instance cleanup operations. Includes permissions for instance management (get, list, stop, start, delete), instance group operations (list, get, delete instances), instance template access, zone listing, and project information retrieval.
     -   `Monitoring Viewer`: To read health metrics from Google Cloud Monitoring.
     -   `Logs Writer`: To write execution logs for debugging and auditing.
     -   `Cloud Functions Invoker`: To allow Cloud Scheduler to trigger the functions securely.
@@ -88,6 +88,7 @@ No modules.
 | [google_cloud_scheduler_job.resource_sync](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
 | [google_cloudfunctions2_function.health_monitor_function](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function) | resource |
 | [google_cloudfunctions2_function.resource_sync_function](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function) | resource |
+| [google_project_iam_custom_role.cloud_function_compute_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_member.cloud_function_instance_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloud_function_logging_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloud_function_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |

--- a/modules/terraform-zscc-cloud-function-gcp/main.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/main.tf
@@ -52,12 +52,48 @@ data "google_service_account" "service_account_function_selected" {
 
 # Cloud Run Function Service Account Permissions
 ################################################################################
-# Assign Service Account the Compute Instance Admin (v1) role
+# Create custom IAM role with minimal compute permissions for health monitoring
+################################################################################
+resource "google_project_iam_custom_role" "cloud_function_compute_role" {
+  role_id     = "${replace(var.name_prefix, "-", "_")}_cloud_function_compute"
+  title       = "Cloud Connector Health Monitor Compute Role"
+  description = "Custom role with minimal compute permissions for health monitoring, autoscaling, and instance cleanup"
+  project     = var.project
+
+  permissions = [
+    # Compute Engine
+    "compute.instances.get",  #InstancesClient.get()` - Get instance details by name
+    "compute.instances.list", #`InstancesClient.list()` - List all instances in a zone
+    "compute.instances.getSerialPortOutput",
+    "compute.instances.stop",
+    "compute.instances.start",
+    "compute.instances.delete",
+    "compute.instances.setMetadata",
+    "compute.instances.setLabels",
+
+    "compute.regionInstanceGroupManagers.list", #`RegionInstanceGroupManagersClient.list_managed_instances()` - List instances in a regional managed instance group
+    "compute.instanceGroupManagers.get",        #`InstanceGroupManagersClient.get()` - Get details of a managed instance group
+    "compute.instanceGroupManagers.list",       #`InstanceGroupManagersClient.list_managed_instances()` - List instances in a managed instance group
+    "compute.instanceGroupManagers.delete",     #`InstanceGroupManagersClient.delete()` - Delete an instance from a managed instance group
+    "compute.instanceGroupManagers.listManagedInstances",
+    "compute.instanceGroupManagers.deleteInstances",
+    "compute.instanceGroupManagers.aggregatedList",
+    "compute.instanceTemplates.get", #`InstanceTemplatesClient.get()` - Get instance template details by name
+    "compute.zones.list",            #`ZonesClient.list()` - List all zones in the region
+
+    # Resource Manager
+    "resourcemanager.projects.get",
+    "compute.instances.getSerialPortOutput",
+  ]
+}
+
+################################################################################
+# Assign Service Account the custom compute role
 ################################################################################
 resource "google_project_iam_member" "cloud_function_instance_admin" {
   count   = var.byo_function_service_account != "" ? 0 : 1
   project = var.project
-  role    = "roles/compute.instanceAdmin.v1"
+  role    = google_project_iam_custom_role.cloud_function_compute_role.id
   member  = "serviceAccount:${var.byo_function_service_account != "" ? data.google_service_account.service_account_function_selected[0].email : google_service_account.service_account_function[0].email}"
 }
 

--- a/modules/terraform-zscc-cloud-function-gcp/main.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/main.tf
@@ -55,8 +55,8 @@ data "google_service_account" "service_account_function_selected" {
 # Create custom IAM role with minimal compute permissions for health monitoring
 ################################################################################
 resource "google_project_iam_custom_role" "cloud_function_compute_role" {
-  role_id     = "${replace(var.name_prefix, "-", "_")}_cloud_function_compute"
-  title       = "Cloud Connector Health Monitor Compute Role"
+  role_id     = "${replace(var.name_prefix, "-", "_")}_cloud_function_compute_role_${replace(var.resource_tag, "-", "_")}"
+  title       = "Cloud Connector Cloud Function Custom Compute Role"
   description = "Custom role with minimal compute permissions for health monitoring, autoscaling, and instance cleanup"
   project     = var.project
 

--- a/modules/terraform-zscc-cloud-function-gcp/main.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/main.tf
@@ -3,6 +3,10 @@
 ################################################################################
 # Create Storage Bucket to store Cloud Function
 resource "google_storage_bucket" "cc_storage_bucket" {
+  versioning {
+    enabled = true
+  }
+
   count                       = var.byo_storage_bucket ? 0 : 1
   name                        = var.storage_bucket_name # Every bucket name must be globally unique
   location                    = var.storage_bucket_location
@@ -55,6 +59,7 @@ data "google_service_account" "service_account_function_selected" {
 # Create custom IAM role with minimal compute permissions for health monitoring
 ################################################################################
 resource "google_project_iam_custom_role" "cloud_function_compute_role" {
+  count       = var.byo_function_service_account != "" ? 0 : 1
   role_id     = "${replace(var.name_prefix, "-", "_")}_cloud_function_compute_role_${replace(var.resource_tag, "-", "_")}"
   title       = "Cloud Connector Cloud Function Custom Compute Role"
   description = "Custom role with minimal compute permissions for health monitoring, autoscaling, and instance cleanup"
@@ -88,7 +93,7 @@ resource "google_project_iam_custom_role" "cloud_function_compute_role" {
 resource "google_project_iam_member" "cloud_function_instance_admin" {
   count   = var.byo_function_service_account != "" ? 0 : 1
   project = var.project
-  role    = google_project_iam_custom_role.cloud_function_compute_role.id
+  role    = google_project_iam_custom_role.cloud_function_compute_role[0].id
   member  = "serviceAccount:${var.byo_function_service_account != "" ? data.google_service_account.service_account_function_selected[0].email : google_service_account.service_account_function[0].email}"
 }
 

--- a/modules/terraform-zscc-cloud-function-gcp/main.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/main.tf
@@ -73,6 +73,7 @@ resource "google_project_iam_custom_role" "cloud_function_compute_role" {
     "compute.instanceGroupManagers.get",    #`InstanceGroupManagersClient.get()` - Get details of a managed instance group
     "compute.instanceGroupManagers.list",   #`InstanceGroupManagersClient.list_managed_instances()` - List instances in a managed instance group
     "compute.instanceGroupManagers.delete", #`InstanceGroupManagersClient.delete()` - Delete an instance from a managed instance group
+    "compute.instanceGroupManagers.update", #`InstanceGroupManagersClient.update()` - Update instance metadata or labels in a managed instance group
     "compute.instanceTemplates.get",        #`InstanceTemplatesClient.get()` - Get instance template details by name
     "compute.zones.list",                   #`ZonesClient.list()` - List all zones in the region
 

--- a/modules/terraform-zscc-cloud-function-gcp/main.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/main.tf
@@ -62,7 +62,6 @@ resource "google_project_iam_custom_role" "cloud_function_compute_role" {
 
   permissions = [
     # Compute Engine
-    "compute.instances.get",  #InstancesClient.get()` - Get instance details by name
     "compute.instances.list", #`InstancesClient.list()` - List all instances in a zone
     "compute.instances.getSerialPortOutput",
     "compute.instances.stop",
@@ -70,20 +69,14 @@ resource "google_project_iam_custom_role" "cloud_function_compute_role" {
     "compute.instances.delete",
     "compute.instances.setMetadata",
     "compute.instances.setLabels",
-
-    "compute.regionInstanceGroupManagers.list", #`RegionInstanceGroupManagersClient.list_managed_instances()` - List instances in a regional managed instance group
-    "compute.instanceGroupManagers.get",        #`InstanceGroupManagersClient.get()` - Get details of a managed instance group
-    "compute.instanceGroupManagers.list",       #`InstanceGroupManagersClient.list_managed_instances()` - List instances in a managed instance group
-    "compute.instanceGroupManagers.delete",     #`InstanceGroupManagersClient.delete()` - Delete an instance from a managed instance group
-    "compute.instanceGroupManagers.listManagedInstances",
-    "compute.instanceGroupManagers.deleteInstances",
-    "compute.instanceGroupManagers.aggregatedList",
-    "compute.instanceTemplates.get", #`InstanceTemplatesClient.get()` - Get instance template details by name
-    "compute.zones.list",            #`ZonesClient.list()` - List all zones in the region
+    "compute.instanceGroupManagers.get",    #`InstanceGroupManagersClient.get()` - Get details of a managed instance group
+    "compute.instanceGroupManagers.list",   #`InstanceGroupManagersClient.list_managed_instances()` - List instances in a managed instance group
+    "compute.instanceGroupManagers.delete", #`InstanceGroupManagersClient.delete()` - Delete an instance from a managed instance group
+    "compute.instanceTemplates.get",        #`InstanceTemplatesClient.get()` - Get instance template details by name
+    "compute.zones.list",                   #`ZonesClient.list()` - List all zones in the region
 
     # Resource Manager
     "resourcemanager.projects.get",
-    "compute.instances.getSerialPortOutput",
   ]
 }
 

--- a/modules/terraform-zscc-cloud-function-gcp/main.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/main.tf
@@ -63,6 +63,7 @@ resource "google_project_iam_custom_role" "cloud_function_compute_role" {
   permissions = [
     # Compute Engine
     "compute.instances.list", #`InstancesClient.list()` - List all instances in a zone
+    "compute.instances.get",  #`InstancesClient.get()` - Get details of an instance
     "compute.instances.getSerialPortOutput",
     "compute.instances.stop",
     "compute.instances.start",


### PR DESCRIPTION
ENHANCEMENTS:
* update: terraform-zscc-cloud-function-gcp module to use a custom project IAM role with minimal Compute Engine permissions instead of the broad roles/compute.instanceAdmin.v1 binding