### PR TITLE
ZTW-10560: align Cloud Function artifact URLs/defaults to S3 us-east-1 and v0.1.2 guidance

### DIFF
--- a/examples/base_cc_asg/README.md
+++ b/examples/base_cc_asg/README.md
@@ -26,16 +26,16 @@ This example deployment script looks for a local zip file of the Cloud Run Funct
 How manually the latest or specific Cloud Function zip file
 
 #### Check for the latest version info
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/version-manifest.json
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/version-manifest.json
 
 #### Download the latest function version
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
 
 #### Download a specific function version (refer to modules/terraform-zscc-cloud-function-gcp/README.md for all published function versions)
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/\<version\>/cloud-functions-\<version\>.zip
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/\<version\>/cloud-functions-\<version\>.zip
 
-##### example v0.1.1 download: 
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/v0.1.1/cloud-functions-v0.1.1.zip
+##### example v0.1.2 download: 
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/v0.1.2/cloud-functions-v0.1.2.zip
 
 From base_cc_asg directory execute:
 - terraform init
@@ -117,7 +117,7 @@ From base_cc_ilb directory execute:
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"n2-standard-2"` | no |
 | <a name="input_cloud_function_service_account_display_name"></a> [cloud\_function\_service\_account\_display\_name](#input\_cloud\_function\_service\_account\_display\_name) | Custom Service Account display name string for Cloud Run Function | `string` | `""` | no |
 | <a name="input_cloud_function_service_account_id"></a> [cloud\_function\_service\_account\_id](#input\_cloud\_function\_service\_account\_id) | Custom Service Account ID string for Cloud Run Function | `string` | `""` | no |
-| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler\_cc\_cloud\_run\_function.zip. Only change if you have renamed the file/path for an existing storage bucket | `string` | `"zscaler_cc_cloud_run_function.zip"` | no |
+| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket | `string` | `"cloud-functions-latest.zip"` | no |
 | <a name="input_cloud_function_source_object_path"></a> [cloud\_function\_source\_object\_path](#input\_cloud\_function\_source\_object\_path) | By default, this Terraform module will download the latest version of the Cloud Run Function ZIP and save it to the root/function\_zip directory. If upload\_cloud\_function\_ip is set to true, this variable path will be used as the source to upload the zip file to the specified Storage Bucket | `string` | `"./function_zip/cloud-functions-latest.zip"` | no |
 | <a name="input_consecutive_unhealthy_threshold"></a> [consecutive\_unhealthy\_threshold](#input\_consecutive\_unhealthy\_threshold) | Consecutive unhealthy metrics threshold (sustained issues) | `number` | `8` | no |
 | <a name="input_cooldown_period"></a> [cooldown\_period](#input\_cooldown\_period) | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. This prevents the autoscaler from collecting information when the instance is initializing, during which the collected usage would not be reliable | `number` | `900` | no |

--- a/examples/base_cc_asg/variables.tf
+++ b/examples/base_cc_asg/variables.tf
@@ -447,8 +447,8 @@ variable "cloud_function_source_object_path" {
 
 variable "cloud_function_source_object_name" {
   type        = string
-  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler_cc_cloud_run_function.zip. Only change if you have renamed the file/path for an existing storage bucket"
-  default     = "zscaler_cc_cloud_run_function.zip"
+  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket"
+  default     = "cloud-functions-latest.zip"
 }
 
 

--- a/examples/base_cc_asg_zpa/README.md
+++ b/examples/base_cc_asg_zpa/README.md
@@ -26,16 +26,16 @@ This example deployment script looks for a local zip file of the Cloud Run Funct
 How manually the latest or specific Cloud Function zip file
 
 #### Check for the latest version info
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/version-manifest.json
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/version-manifest.json
 
 #### Download the latest function version
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
 
 #### Download a specific function version (refer to modules/terraform-zscc-cloud-function-gcp/README.md for all published function versions)
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/\<version\>/cloud-functions-\<version\>.zip
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/\<version\>/cloud-functions-\<version\>.zip
 
-##### example v0.1.1 download: 
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/v0.1.1/cloud-functions-v0.1.1.zip
+##### example v0.1.2 download: 
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/v0.1.2/cloud-functions-v0.1.2.zip
 
 From base_cc_asg directory execute:
 - terraform init
@@ -118,7 +118,7 @@ From base_cc_ilb directory execute:
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"n2-standard-2"` | no |
 | <a name="input_cloud_function_service_account_display_name"></a> [cloud\_function\_service\_account\_display\_name](#input\_cloud\_function\_service\_account\_display\_name) | Custom Service Account display name string for Cloud Run Function | `string` | `""` | no |
 | <a name="input_cloud_function_service_account_id"></a> [cloud\_function\_service\_account\_id](#input\_cloud\_function\_service\_account\_id) | Custom Service Account ID string for Cloud Run Function | `string` | `""` | no |
-| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler\_cc\_cloud\_run\_function.zip. Only change if you have renamed the file/path for an existing storage bucket | `string` | `"zscaler_cc_cloud_run_function.zip"` | no |
+| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket | `string` | `"cloud-functions-latest.zip"` | no |
 | <a name="input_cloud_function_source_object_path"></a> [cloud\_function\_source\_object\_path](#input\_cloud\_function\_source\_object\_path) | By default, this Terraform module will download the latest version of the Cloud Run Function ZIP and save it to the root/function\_zip directory. If upload\_cloud\_function\_ip is set to true, this variable path will be used as the source to upload the zip file to the specified Storage Bucket | `string` | `"./function_zip/cloud-functions-latest.zip"` | no |
 | <a name="input_consecutive_unhealthy_threshold"></a> [consecutive\_unhealthy\_threshold](#input\_consecutive\_unhealthy\_threshold) | Consecutive unhealthy metrics threshold (sustained issues) | `number` | `8` | no |
 | <a name="input_cooldown_period"></a> [cooldown\_period](#input\_cooldown\_period) | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. This prevents the autoscaler from collecting information when the instance is initializing, during which the collected usage would not be reliable | `number` | `900` | no |

--- a/examples/base_cc_asg_zpa/variables.tf
+++ b/examples/base_cc_asg_zpa/variables.tf
@@ -446,8 +446,8 @@ variable "cloud_function_source_object_path" {
 
 variable "cloud_function_source_object_name" {
   type        = string
-  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler_cc_cloud_run_function.zip. Only change if you have renamed the file/path for an existing storage bucket"
-  default     = "zscaler_cc_cloud_run_function.zip"
+  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket"
+  default     = "cloud-functions-latest.zip"
 }
 
 

--- a/examples/cc_asg/README.md
+++ b/examples/cc_asg/README.md
@@ -27,16 +27,16 @@ This example deployment script looks for a local zip file of the Cloud Run Funct
 How manually the latest or specific Cloud Function zip file
 
 #### Check for the latest version info
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/version-manifest.json
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/version-manifest.json
 
 #### Download the latest function version
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
 
 #### Download a specific function version (refer to modules/terraform-zscc-cloud-function-gcp/README.md for all published function versions)
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/\<version\>/cloud-functions-\<version\>.zip
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/\<version\>/cloud-functions-\<version\>.zip
 
-##### example v0.1.1 download: 
-https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/v0.1.1/cloud-functions-v0.1.1.zip
+##### example v0.1.2 download: 
+https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/v0.1.2/cloud-functions-v0.1.2.zip
 
 From base_cc_asg directory execute:
 - terraform init
@@ -126,7 +126,7 @@ From cc_asg directory execute:
 | <a name="input_ccvm_instance_type"></a> [ccvm\_instance\_type](#input\_ccvm\_instance\_type) | Cloud Connector Instance Type | `string` | `"n2-standard-2"` | no |
 | <a name="input_cloud_function_service_account_display_name"></a> [cloud\_function\_service\_account\_display\_name](#input\_cloud\_function\_service\_account\_display\_name) | Custom Service Account display name string for Cloud Run Function | `string` | `""` | no |
 | <a name="input_cloud_function_service_account_id"></a> [cloud\_function\_service\_account\_id](#input\_cloud\_function\_service\_account\_id) | Custom Service Account ID string for Cloud Run Function | `string` | `""` | no |
-| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler\_cc\_cloud\_run\_function.zip. Only change if you have renamed the file/path for an existing storage bucket | `string` | `"zscaler_cc_cloud_run_function.zip"` | no |
+| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket | `string` | `"cloud-functions-latest.zip"` | no |
 | <a name="input_cloud_function_source_object_path"></a> [cloud\_function\_source\_object\_path](#input\_cloud\_function\_source\_object\_path) | By default, this Terraform module will download the latest version of the Cloud Run Function ZIP and save it to the root/function\_zip directory. If upload\_cloud\_function\_ip is set to true, this variable path will be used as the source to upload the zip file to the specified Storage Bucket | `string` | `"./function_zip/cloud-functions-latest.zip"` | no |
 | <a name="input_consecutive_unhealthy_threshold"></a> [consecutive\_unhealthy\_threshold](#input\_consecutive\_unhealthy\_threshold) | Consecutive unhealthy metrics threshold (sustained issues) | `number` | `8` | no |
 | <a name="input_cooldown_period"></a> [cooldown\_period](#input\_cooldown\_period) | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. This prevents the autoscaler from collecting information when the instance is initializing, during which the collected usage would not be reliable | `number` | `900` | no |

--- a/examples/cc_asg/variables.tf
+++ b/examples/cc_asg/variables.tf
@@ -506,8 +506,8 @@ variable "cloud_function_source_object_path" {
 
 variable "cloud_function_source_object_name" {
   type        = string
-  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler_cc_cloud_run_function.zip. Only change if you have renamed the file/path for an existing storage bucket"
-  default     = "zscaler_cc_cloud_run_function.zip"
+  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket"
+  default     = "cloud-functions-latest.zip"
 }
 
 

--- a/examples/zsec
+++ b/examples/zsec
@@ -599,9 +599,9 @@ Else, you will need to add this new service account to your HCP Vault before Clo
                 cloud_function_version=latest
                 zip_name="cloud-functions-$cloud_function_version.zip"
                 if [[ $cloud_function_version == "latest" ]]; then
-                    URL=https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/latest/$zip_name
+                    URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/$zip_name
                 else
-                    URL=https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/$cloud_function_version/$zip_name
+                    URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/$cloud_function_version/$zip_name
                 fi
                 echo "${GREEN}Starting download of: $URL${GREEN}"
                 echo "Saving as: $dtype/function_zip/cloud-functions-latest.zip"

--- a/modules/terraform-zscc-cloud-function-gcp/README.md
+++ b/modules/terraform-zscc-cloud-function-gcp/README.md
@@ -11,7 +11,11 @@ This Terraform module deploys a comprehensive solution for monitoring and managi
 
 | Function ZIP Version | SHA256 Hash | GitHub Release Date/Tag |
 | ----------- | --------| ------------ |
-| 0.1.1 | d9a9c2f07aeed8b26f238c67365cf7a5fbfc7ae9959dfdc1136030bc18d8419c | 02/06/2026 - [v0.1.1](https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip) |
+| 0.1.2 | Refer to `version-manifest.json` | 06/17/2026 - [v0.1.2](https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/v0.1.2/cloud-functions-v0.1.2.zip) |
+| 0.1.1 | d9a9c2f07aeed8b26f238c67365cf7a5fbfc7ae9959dfdc1136030bc18d8419c | 02/06/2026 - [v0.1.1](https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/v0.1.1/cloud-functions-v0.1.1.zip) |
+
+- Latest version manifest: `https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/version-manifest.json`
+- Latest stable ZIP: `https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip`
 
 ## Purpose
 
@@ -116,7 +120,7 @@ No modules.
 | <a name="input_cc_vm_prov_url"></a> [cc\_vm\_prov\_url](#input\_cc\_vm\_prov\_url) | Zscaler Cloud Connector Provisioning URL | `string` | n/a | yes |
 | <a name="input_cloud_function_service_account_display_name"></a> [cloud\_function\_service\_account\_display\_name](#input\_cloud\_function\_service\_account\_display\_name) | Custom Service Account display name string for Cloud Run Function | `string` | `""` | no |
 | <a name="input_cloud_function_service_account_id"></a> [cloud\_function\_service\_account\_id](#input\_cloud\_function\_service\_account\_id) | Custom Service Account ID string for Cloud Run Function | `string` | `""` | no |
-| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler\_cc\_cloud\_run\_function.zip. Only change if you have renamed the file/path for an existing storage bucket | `string` | `"zscaler_cc_cloud_run_function.zip"` | no |
+| <a name="input_cloud_function_source_object_name"></a> [cloud\_function\_source\_object\_name](#input\_cloud\_function\_source\_object\_name) | Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket | `string` | `"cloud-functions-latest.zip"` | no |
 | <a name="input_cloud_function_source_object_path"></a> [cloud\_function\_source\_object\_path](#input\_cloud\_function\_source\_object\_path) | By default, this Terraform module will download the latest version of the Cloud Run Function ZIP and save it to the root/function\_zip directory. If upload\_cloud\_function\_ip is set to true, this variable path will be used as the source to upload the zip file to the specified Storage Bucket | `string` | `""` | no |
 | <a name="input_consecutive_unhealthy_threshold"></a> [consecutive\_unhealthy\_threshold](#input\_consecutive\_unhealthy\_threshold) | Consecutive unhealthy metrics threshold (sustained issues) | `number` | `8` | no |
 | <a name="input_enable_scheduler"></a> [enable\_scheduler](#input\_enable\_scheduler) | Whether to create Cloud Scheduler jobs | `bool` | `true` | no |

--- a/modules/terraform-zscc-cloud-function-gcp/variables.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/variables.tf
@@ -205,16 +205,16 @@ variable "cloud_function_source_object_path" {
 
 variable "cloud_function_source_object_name" {
   type        = string
-  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to zscaler_cc_cloud_run_function.zip. Only change if you have renamed the file/path for an existing storage bucket"
-  default     = "zscaler_cc_cloud_run_function.zip"
+  description = "Name of existing Storage Bucket Object (zip file) name. Defaults to cloud-functions-latest.zip. Only change if you are pinning a specific release object (for example cloud-functions-v0.1.2.zip) or have renamed the object in your storage bucket"
+  default     = "cloud-functions-latest.zip"
 }
 
 # Check for the latest version info)
-#https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/version-manifest.json
+#https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/version-manifest.json
 
 # Download the latest function version
-#https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
+#https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
 
 # Download a specific function version (refer to modules/terraform-zscc-cloud-function-gcp/README.md for all published function versions)
-#https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/<version>/cloud-functions-<version>.zip
-# example v0.1.1 download: https://zscaler-cc-functions-artifacts.s3.amazonaws.com/zscaler-cc-functions/releases/v0.1.1/cloud-functions-v0.1.1.zip
+#https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/<version>/cloud-functions-<version>.zip
+# example v0.1.2 download: https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/v0.1.2/cloud-functions-v0.1.2.zip


### PR DESCRIPTION
## Summary

Align Cloud Function artifact consumption defaults and documentation with the actual S3 artifact layout (`us-east-1` regional endpoint), and update version guidance to `v0.1.2`.

## Changes

- Updated Cloud Function source object defaults to canonical latest object naming:
  - `cloud_function_source_object_name = "cloud-functions-latest.zip"`
- Kept latest behavior as default while documenting explicit pinning support (for example `cloud-functions-v0.1.2.zip`).

### URL alignment (regional endpoint)

Replaced `s3.amazonaws.com` artifact references with:

`https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/...`

across:
- module variable guidance/comments
- module README artifact links
- example READMEs (`base_cc_asg`, `base_cc_asg_zpa`, `cc_asg`)
- [examples/zsec](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/zsec:0:0-0:0) download URLs (latest + releases)

### Version guidance update

- Updated specific-version examples from `v0.1.1` to `v0.1.2`.

## Files Changed

- [modules/terraform-zscc-cloud-function-gcp/variables.tf](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/modules/terraform-zscc-cloud-function-gcp/variables.tf:0:0-0:0)
- [modules/terraform-zscc-cloud-function-gcp/README.md](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/modules/terraform-zscc-cloud-function-gcp/README.md:0:0-0:0)
- [examples/base_cc_asg/variables.tf](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/base_cc_asg/variables.tf:0:0-0:0)
- [examples/base_cc_asg/README.md](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/base_cc_asg/README.md:0:0-0:0)
- [examples/base_cc_asg_zpa/variables.tf](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/base_cc_asg_zpa/variables.tf:0:0-0:0)
- [examples/base_cc_asg_zpa/README.md](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/base_cc_asg_zpa/README.md:0:0-0:0)
- [examples/cc_asg/variables.tf](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/cc_asg/variables.tf:0:0-0:0)
- [examples/cc_asg/README.md](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/cc_asg/README.md:0:0-0:0)
- [examples/zsec](cci:7://file:///Users/vkrishnamurthy/workspace/development/june2026/terraform-gcp-cloud-connector-modules/examples/zsec:0:0-0:0)

## Why

Artifact hosting is organized under:
- `latest/`
- `releases/`
- `version-manifest.json`

and served from the bucket’s regional endpoint (`us-east-1`).  
This PR makes defaults and docs consistent with that published layout and current tested rollout (`v0.1.2`).

## Validation

- `terraform fmt` passed (pre-commit)
- `terraform validate` passed (pre-commit)
- `terraform-docs` passed (pre-commit)
- `tflint` validation hook passed (pre-commit)

