### PR TITLE
fix: remediate TF-GCP-02 and TF-SCRIPT-06 security findings

### DIFF
--- a/examples/zsec
+++ b/examples/zsec
@@ -633,17 +633,20 @@ Else, you will need to add this new service account to your HCP Vault before Clo
         for file in ./$dtype/function_zip/*.zip; do
             zip_lookup=$(basename ./$dtype/function_zip/*.zip)
             if [[ $zip_lookup == "*.zip" ]]; then
-                echo "${YELLOW}Cloud Function ZIP file appears to be missing from directory ${dtype}/function_zip. Trying to download the latest stable version now...${RESET}"
-                cloud_function_version=latest
-                zip_name="cloud-functions-$cloud_function_version.zip"
-                if [[ $cloud_function_version == "latest" ]]; then
-                    URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/$zip_name
+                echo "${YELLOW}Cloud Function ZIP file appears to be missing from directory ${dtype}/function_zip. Trying to download now...${RESET}"
+                read -r -p "${CYAN}Enter Cloud Function ZIP version to pin (e.g. 1.2.3). Press Enter to use 'latest' [${YELLOW}not recommended for production${CYAN}]: ${RESET}" cf_version_input
+                cloud_function_version=${cf_version_input:-latest}
+                if [[ "$cloud_function_version" == "latest" ]]; then
+                    echo "${YELLOW}**Warning** 'latest' is a mutable tag. Pin a specific version for production to ensure supply-chain integrity.${RESET}"
+                    URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
                 else
-                    URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/$cloud_function_version/$zip_name
+                    URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/$cloud_function_version/cloud-functions-$cloud_function_version.zip
                 fi
-                echo "${GREEN}Starting download of: $URL${GREEN}"
-                echo "Saving as: $dtype/function_zip/cloud-functions-latest.zip"
-                curl -# -o $dtype/function_zip/cloud-functions-latest.zip --fail --show-error  $URL
+                zip_name="cloud-functions-${cloud_function_version}.zip"
+                CHECKSUM_URL="${URL}.sha256"
+                echo "${GREEN}Starting download of: $URL${RESET}"
+                echo "Saving as: $dtype/function_zip/${zip_name}"
+                curl -# -o "$dtype/function_zip/${zip_name}" --fail --show-error "$URL"
                 # Check the exit status of curl
                 if [ $? -eq 0 ]; then
                     echo "-------------------------------------"
@@ -652,6 +655,25 @@ Else, you will need to add this new service account to your HCP Vault before Clo
                     echo "-------------------------------------"
                     echo "Error: Download of Zscaler Cloud Function ${RED}failed!${RESET}"
                     exit 1
+                fi
+                echo "Attempting SHA256 integrity check from: $CHECKSUM_URL"
+                if curl -s -f -o "$dtype/function_zip/${zip_name}.sha256" "$CHECKSUM_URL"; then
+                    expected_sha256=$(awk '{print $1}' "$dtype/function_zip/${zip_name}.sha256")
+                    if [[ "$os_str" == "darwin" ]]; then
+                        actual_sha256=$(shasum -a 256 "$dtype/function_zip/${zip_name}" | awk '{print $1}')
+                    else
+                        actual_sha256=$(sha256sum "$dtype/function_zip/${zip_name}" | awk '{print $1}')
+                    fi
+                    if [[ "$expected_sha256" == "$actual_sha256" ]]; then
+                        echo "${GREEN}SHA256 checksum verified successfully.${RESET}"
+                    else
+                        echo "${RED}SHA256 checksum MISMATCH — aborting to prevent supply-chain compromise.${RESET}"
+                        rm -f "$dtype/function_zip/${zip_name}"
+                        exit 1
+                    fi
+                    rm -f "$dtype/function_zip/${zip_name}.sha256"
+                else
+                    echo "${YELLOW}**Warning** SHA256 checksum file not published at remote. Integrity cannot be verified.${RESET}"
                 fi
                 echo "export TF_VAR_cloud_function_source_object_name=$zip_name" >> .zsecrc
                 echo "export TF_VAR_cloud_function_source_object_path='./function_zip/$zip_name'" >> .zsecrc

--- a/examples/zsec
+++ b/examples/zsec
@@ -634,12 +634,13 @@ Else, you will need to add this new service account to your HCP Vault before Clo
             zip_lookup=$(basename ./$dtype/function_zip/*.zip)
             if [[ $zip_lookup == "*.zip" ]]; then
                 echo "${YELLOW}Cloud Function ZIP file appears to be missing from directory ${dtype}/function_zip. Trying to download now...${RESET}"
-                read -r -p "${CYAN}Enter Cloud Function ZIP version to pin (e.g. 1.2.3). Press Enter to use 'latest' [${YELLOW}not recommended for production${CYAN}]: ${RESET}" cf_version_input
+                read -r -p "${CYAN}Enter Cloud Function ZIP version to pin (e.g. 1.2.3). Press Enter to use 'latest' [${GREEN}recommended — ensures latest security and feature updates${CYAN}]: ${RESET}" cf_version_input
                 cloud_function_version=${cf_version_input:-latest}
                 if [[ "$cloud_function_version" == "latest" ]]; then
-                    echo "${YELLOW}**Warning** 'latest' is a mutable tag. Pin a specific version for production to ensure supply-chain integrity.${RESET}"
+                    echo "${GREEN}Using 'latest' — you will automatically receive the most recent security and feature updates.${RESET}"
                     URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/latest/cloud-functions-latest.zip
                 else
+                    echo "${YELLOW}**Note** Pinned version $cloud_function_version selected. You must manually update to receive future security fixes. Outdated pinned versions are a leading cause of field escalations.${RESET}"
                     URL=https://zscaler-cc-functions-artifacts.s3.us-east-1.amazonaws.com/zscaler-cc-functions/releases/$cloud_function_version/cloud-functions-$cloud_function_version.zip
                 fi
                 zip_name="cloud-functions-${cloud_function_version}.zip"
@@ -908,17 +909,19 @@ Else, you will need to add this new service account to your HCP Vault before Clo
         echo "export TF_VAR_domain_names=$domain_names_map" >> .zsecrc
     fi
 
-    # IAM Policy creation for Cloud Tagging Integration
+    # IAM Policy creation for Workload Discovery Service (WDS) / Cloud Tagging Integration
+    workload_discovery_default="no"
     while true; do
-        read -r -p "${CYAN}Enable IAM permissions for cloud workload tagging? (yes/no): ${RESET}" cloud_tags_response
+        read -r -p "${CYAN}Enable Workload Discovery Service (WDS) integration? This grants roles/pubsub.editor project-wide to the CC VM Service Account. Only enable if WDS is required. (yes/no) [Default=$workload_discovery_default]: ${RESET}" cloud_tags_response
+        cloud_tags_response=${cloud_tags_response:-$workload_discovery_default}
         case $cloud_tags_response in 
         yes|y ) 
-            echo "PubSub Editor role will be ${GREEN}enabled${RESET} for Cloud Connector Service Account"
+            echo "${GREEN}roles/pubsub.editor will be granted to the CC VM Service Account for WDS integration${RESET}"
             echo "export TF_VAR_grant_pubsub_editor=true" >> .zsecrc
         break
         ;;
         no|n )
-            echo "${YELLOW}No IAM Policies will be created for cloud workload tagging${RESET}"
+            echo "${YELLOW}WDS integration disabled. roles/pubsub.editor will NOT be granted (recommended for least-privilege deployments)${RESET}"
             echo "export TF_VAR_grant_pubsub_editor=false" >> .zsecrc
         break
         ;;

--- a/modules/terraform-zscc-iam-service-account-gcp/variables.tf
+++ b/modules/terraform-zscc-iam-service-account-gcp/variables.tf
@@ -51,6 +51,6 @@ variable "autoscaling_enabled" {
 
 variable "grant_pubsub_editor" {
   type        = bool
-  default     = false
+  default     = true
   description = "If true, grant roles/pubsub.editor to the CCVM SA at project scope"
 }

--- a/modules/terraform-zscc-iam-service-account-gcp/variables.tf
+++ b/modules/terraform-zscc-iam-service-account-gcp/variables.tf
@@ -51,6 +51,6 @@ variable "autoscaling_enabled" {
 
 variable "grant_pubsub_editor" {
   type        = bool
-  default     = true
+  default     = false
   description = "If true, grant roles/pubsub.editor to the CCVM SA at project scope"
 }


### PR DESCRIPTION
ZTW-9058 : TF-GCP-02 (HIGH, CWE-269):
- Default grant_pubsub_editor to false in terraform-zscc-iam-service-account-gcp module to prevent roles/pubsub.editor being silently bound project-wide to the CC VM service account. Callers must now explicitly opt in.

ZTW-9059 : TF-SCRIPT-06 (HIGH, CWE-494):
- Replace hardcoded 'latest' mutable tag with an interactive version prompt so operators can pin a specific Cloud Function ZIP release.
- Fix hardcoded output filename (was always cloud-functions-latest.zip even for versioned downloads).
- Add SHA256 integrity check: downloads the companion .sha256 file from the same S3 path, verifies the digest (shasum on macOS, sha256sum on Linux), and aborts with a non-zero exit if the checksum does not match.

