### PR TITLE
BUG-238838: change resource_sync cron from */10 to */30

### DIFF
--- a/modules/terraform-zscc-cloud-function-gcp/main.tf
+++ b/modules/terraform-zscc-cloud-function-gcp/main.tf
@@ -332,8 +332,8 @@ resource "google_cloud_scheduler_job" "resource_sync" {
   count = var.enable_scheduler ? 1 : 0
 
   name             = "${var.name_prefix}-resource-sync-job-${var.resource_tag}"
-  description      = "Triggers resource sync every 10 minutes"
-  schedule         = "*/10 * * * *"
+  description      = "Triggers resource sync every 30 minutes"
+  schedule         = "*/30 * * * *"
   time_zone        = "UTC"
   region           = var.region
   attempt_deadline = "600s"


### PR DESCRIPTION
Reduces the frequency at which the resource_sync Cloud Function samples GCP MIG vs Zscaler EC-group state, cutting the probability of hitting the TOCTOU delete race described in BUG-238838.

This is a statistical mitigation, not a code fix. The underlying race in resource_sync_entry (main.py:604) requires a min-age gate in the Cloud Function itself; that lives in the private cloud-functions repo and is tracked separately.

